### PR TITLE
Feature/support for multiple secret files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   secretsfile:
     description: 'Path of the secret file to be fetched' #Comma separated list of secret keys can be specified
     required: false
+  key_vault_with_secret_file_pairs:
+    description: 'List of key vaults and secret files to be fetched'
+    required: false
 branding:
   icon: 'akv.svg'
   color: 'blue'

--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ branding:
   icon: 'akv.svg'
   color: 'blue'
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'lib/main.js'

--- a/lib/KeyVaultActionParameters.js
+++ b/lib/KeyVaultActionParameters.js
@@ -27,6 +27,19 @@ exports.KeyVaultActionParameters = void 0;
 const util = require("util");
 const core = __importStar(require("@actions/core"));
 class KeyVaultActionParameters {
+    getKeyVaultActionParametersForSpecificKeyVaultWithFile(handler, keyVault, secretsPath) {
+        this.keyVaultName = keyVault;
+        this.secretsFilePath = secretsPath;
+        if (!this.keyVaultName) {
+            core.setFailed("Vault name not provided.");
+        }
+        if (!this.secretsFilePath) {
+            core.setFailed("SecretsFilePath should be provided");
+        }
+        var azureKeyVaultDnsSuffix = handler.getCloudSuffixUrl("keyvaultDns").substring(1);
+        this.keyVaultUrl = util.format("https://%s.%s", this.keyVaultName, azureKeyVaultDnsSuffix);
+        return this;
+    }
     getKeyVaultActionParameters(handler) {
         this.keyVaultName = core.getInput("keyvault");
         this.secretsFilter = core.getInput("secrets");

--- a/lib/KeyVaultHelper.js
+++ b/lib/KeyVaultHelper.js
@@ -146,7 +146,7 @@ class KeyVaultHelper {
         for (const filePath of filePaths) {
             console.log(`Reading key values from file: ${filePath}`);
             const fileContent = (0, fs_1.readFileSync)(filePath, 'utf8');
-            const lines = fileContent.split(',');
+            const lines = fileContent.split('\n');
             for (const line of lines) {
                 const trimmedLine = line.trim();
                 console.log(`Reading key values from line: ${trimmedLine}`);

--- a/lib/KeyVaultHelper.js
+++ b/lib/KeyVaultHelper.js
@@ -60,6 +60,7 @@ class KeyVaultHelper {
             return this.downloadAllSecrets();
         }
         else {
+            console.log(`Downloading selected secrets with filter: ${this.keyVaultActionParameters.secretsFilter}`);
             let selectedSecrets = this.readKeyValuesFromFilter(this.keyVaultActionParameters.secretsFilter);
             return this.downloadSelectedSecrets(selectedSecrets);
         }
@@ -91,6 +92,7 @@ class KeyVaultHelper {
         return new Promise((resolve, reject) => {
             var getSecretValuePromises = [];
             secretsMap.forEach((secretName, secretEnv) => {
+                console.log(util.format("Downloading secret %s", secretName));
                 getSecretValuePromises.push(this.downloadSecretValue(secretName, secretEnv));
             });
             Promise.all(getSecretValuePromises).then(() => {
@@ -101,13 +103,14 @@ class KeyVaultHelper {
         });
     }
     downloadSecretValue(secretName, secretEnv) {
-        //secretName = secretName.trim();
         return new Promise((resolve, reject) => {
             this.keyVaultClient.getSecretValue(secretName, (error, secretValue) => {
                 if (error) {
+                    console.log(util.format("Failed to download secret %s", secretName));
                     core.setFailed(util.format("Could not download the secret %s", secretName));
                 }
                 else {
+                    console.log(util.format("Downloaded secret %s", secretName));
                     this.setVaultVariable(secretEnv, secretValue);
                 }
                 return resolve();
@@ -134,12 +137,19 @@ class KeyVaultHelper {
     }
     readKeyValuesFromFile(filePattern) {
         const keyValueMap = new Map();
+        console.log(`Reading key values from file pattern: ${filePattern}`);
         const filePaths = (0, glob_1.sync)(filePattern);
+        console.log(`Found ${filePaths.length} files matching the pattern: ${filePattern}`);
+        if (filePaths.length === 0) {
+            core.setFailed("No files found matching the pattern: " + filePattern);
+        }
         for (const filePath of filePaths) {
+            console.log(`Reading key values from file: ${filePath}`);
             const fileContent = (0, fs_1.readFileSync)(filePath, 'utf8');
-            const lines = fileContent.split('\n');
+            const lines = fileContent.split(',');
             for (const line of lines) {
                 const trimmedLine = line.trim();
+                console.log(`Reading key values from line: ${trimmedLine}`);
                 if (trimmedLine) {
                     const [key, value] = trimmedLine.split('=');
                     keyValueMap.set(key.trim(), value.trim());

--- a/lib/main.js
+++ b/lib/main.js
@@ -56,16 +56,36 @@ function run() {
                 core.setFailed("Could not login to Azure.");
             }
             if (handler != null) {
-                var actionParameters = new KeyVaultActionParameters_1.KeyVaultActionParameters().getKeyVaultActionParameters(handler);
-                var keyVaultHelper = new KeyVaultHelper_1.KeyVaultHelper(handler, 100, actionParameters);
                 azPath = yield io.which("az", true);
                 var environment = yield executeAzCliCommand("cloud show --query name");
                 environment = environment.replace(/"|\s/g, '');
                 console.log('Running keyvault action against ' + environment);
-                if (environment.toLowerCase() == "azurestack") {
-                    yield keyVaultHelper.initKeyVaultClient();
+                var keyVaultName = core.getInput("keyvault");
+                var secrets = core.getInput("secrets");
+                if (keyVaultName && secrets) {
+                    // this code works only when keyvault and secrets are provided as input, for backward compatibility with the version 2
+                    console.log('Running keyvault action against input param ' + keyVaultName);
+                    console.log('Running keyvault action against with secrets ' + secrets);
+                    var actionParameters = new KeyVaultActionParameters_1.KeyVaultActionParameters().getKeyVaultActionParameters(handler);
+                    downloadSecrets(handler, environment, actionParameters);
                 }
-                keyVaultHelper.downloadSecrets();
+                var keyVaultPairsInput = core.getInput("key_vault_with_secret_file_pairs");
+                if (keyVaultPairsInput) {
+                    // param key_vault_with_secret_file_pairs in github action looks like this:
+                    //      key_vault_with_secret_file_pairs: |
+                    //          infra-eu-dev-kv=.github/env/eu/dev/key_vault1.env
+                    //          business-eu-dev-kv=.github/env/eu/dev/key_vault2.env
+                    var keyVaultPairs = keyVaultPairsInput.split('\n');
+                    for (var i = 0; i < keyVaultPairs.length; i++) {
+                        var keyVaultPair = keyVaultPairs[i].split('=');
+                        var keyVault = keyVaultPair[0];
+                        var secretsFilePath = keyVaultPair[1];
+                        console.log('Running keyvault action against ' + keyVault);
+                        console.log('Running keyvault action against with secret file ' + secretsFilePath);
+                        var actionParameters = new KeyVaultActionParameters_1.KeyVaultActionParameters().getKeyVaultActionParametersForSpecificKeyVaultWithFile(handler, keyVault, secretsFilePath);
+                        downloadSecrets(handler, environment, actionParameters);
+                    }
+                }
             }
         }
         catch (error) {
@@ -75,6 +95,15 @@ function run() {
         finally {
             core.exportVariable('AZURE_HTTP_USER_AGENT', prefix);
         }
+    });
+}
+function downloadSecrets(handler, environment, actionParameters) {
+    return __awaiter(this, void 0, void 0, function* () {
+        var keyVaultHelper = new KeyVaultHelper_1.KeyVaultHelper(handler, 100, actionParameters);
+        if (environment.toLowerCase() == "azurestack") {
+            yield keyVaultHelper.initKeyVaultClient();
+        }
+        keyVaultHelper.downloadSecrets();
     });
 }
 function executeAzCliCommand(command) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -67,7 +67,7 @@ function run() {
                     console.log('Running keyvault action against input param ' + keyVaultName);
                     console.log('Running keyvault action against with secrets ' + secrets);
                     var actionParameters = new KeyVaultActionParameters_1.KeyVaultActionParameters().getKeyVaultActionParameters(handler);
-                    downloadSecrets(handler, environment, actionParameters);
+                    yield downloadSecrets(handler, environment, actionParameters);
                 }
                 var keyVaultPairsInput = core.getInput("key_vault_with_secret_file_pairs");
                 if (keyVaultPairsInput) {
@@ -83,7 +83,7 @@ function run() {
                         console.log('Running keyvault action against ' + keyVault);
                         console.log('Running keyvault action against with secret file ' + secretsFilePath);
                         var actionParameters = new KeyVaultActionParameters_1.KeyVaultActionParameters().getKeyVaultActionParametersForSpecificKeyVaultWithFile(handler, keyVault, secretsFilePath);
-                        downloadSecrets(handler, environment, actionParameters);
+                        yield downloadSecrets(handler, environment, actionParameters);
                     }
                 }
             }

--- a/lib/main.js
+++ b/lib/main.js
@@ -60,8 +60,8 @@ function run() {
                 var environment = yield executeAzCliCommand("cloud show --query name");
                 environment = environment.replace(/"|\s/g, '');
                 console.log('Running keyvault action against ' + environment);
-                var keyVaultName = core.getInput("keyvault");
-                var secrets = core.getInput("secrets");
+                var keyVaultName = core.getInput("keyvault").trim();
+                var secrets = core.getInput("secrets").trim();
                 if (keyVaultName && secrets) {
                     // this code works only when keyvault and secrets are provided as input, for backward compatibility with the version 2
                     console.log('Running keyvault action against input param ' + keyVaultName);
@@ -73,13 +73,13 @@ function run() {
                 if (keyVaultPairsInput) {
                     // param key_vault_with_secret_file_pairs in github action looks like this:
                     //      key_vault_with_secret_file_pairs: |
-                    //          infra-eu-dev-kv=.github/env/eu/dev/key_vault1.env
+                    //          infra-eu-dev-kv=.github/env/eu/dev/key_vault1.env,
                     //          business-eu-dev-kv=.github/env/eu/dev/key_vault2.env
-                    var keyVaultPairs = keyVaultPairsInput.split('\n');
+                    var keyVaultPairs = keyVaultPairsInput.split(',');
                     for (var i = 0; i < keyVaultPairs.length; i++) {
-                        var keyVaultPair = keyVaultPairs[i].split('=');
-                        var keyVault = keyVaultPair[0];
-                        var secretsFilePath = keyVaultPair[1];
+                        var keyVaultPair = keyVaultPairs[i].trim().split('=');
+                        var keyVault = keyVaultPair[0].trim();
+                        var secretsFilePath = keyVaultPair[1].trim();
                         console.log('Running keyvault action against ' + keyVault);
                         console.log('Running keyvault action against with secret file ' + secretsFilePath);
                         var actionParameters = new KeyVaultActionParameters_1.KeyVaultActionParameters().getKeyVaultActionParametersForSpecificKeyVaultWithFile(handler, keyVault, secretsFilePath);
@@ -113,7 +113,7 @@ function executeAzCliCommand(command) {
         try {
             core.debug(`"${azPath}" ${command}`);
             yield exec.exec(`"${azPath}" ${command}`, [], {
-                silent: true,
+                silent: true, // this will prevent priniting access token to console output
                 listeners: {
                     stdout: (data) => { stdout += data.toString(); },
                     stderr: (data) => { stderr += data.toString(); }

--- a/src/KeyVaultActionParameters.ts
+++ b/src/KeyVaultActionParameters.ts
@@ -8,6 +8,23 @@ export class KeyVaultActionParameters {
     public secretsFilter: string;
     public keyVaultUrl: string;
     public secretsFilePath: string;
+    
+    public getKeyVaultActionParametersForSpecificKeyVaultWithFile(handler: IAuthorizer, keyVault: string, secretsPath: string) : KeyVaultActionParameters {
+      this.keyVaultName = keyVault;
+      this.secretsFilePath = secretsPath;
+
+      if (!this.keyVaultName) {
+          core.setFailed("Vault name not provided.");
+      }
+
+      if (!this.secretsFilePath) {
+        core.setFailed("SecretsFilePath should be provided");
+      }
+
+      var azureKeyVaultDnsSuffix = handler.getCloudSuffixUrl("keyvaultDns").substring(1);
+      this.keyVaultUrl = util.format("https://%s.%s", this.keyVaultName, azureKeyVaultDnsSuffix);
+      return this;
+    }
 
     public getKeyVaultActionParameters(handler: IAuthorizer) : KeyVaultActionParameters {
         this.keyVaultName = core.getInput("keyvault");

--- a/src/KeyVaultHelper.ts
+++ b/src/KeyVaultHelper.ts
@@ -140,7 +140,7 @@ export class KeyVaultHelper {
       for (const filePath of filePaths) {
         console.log(`Reading key values from file: ${filePath}`);
         const fileContent = readFileSync(filePath, 'utf8');
-        const lines = fileContent.split(',');
+        const lines = fileContent.split('\n');
 
         for (const line of lines) {
           const trimmedLine = line.trim();

--- a/src/KeyVaultHelper.ts
+++ b/src/KeyVaultHelper.ts
@@ -36,6 +36,7 @@ export class KeyVaultHelper {
         if (this.keyVaultActionParameters.secretsFilter && this.keyVaultActionParameters.secretsFilter.length === 1 && this.keyVaultActionParameters.secretsFilter[0] === "*") {
              return this.downloadAllSecrets();
         } else {
+            console.log(`Downloading selected secrets with filter: ${this.keyVaultActionParameters.secretsFilter}`);
             let selectedSecrets = this.readKeyValuesFromFilter(this.keyVaultActionParameters.secretsFilter);
             return this.downloadSelectedSecrets(selectedSecrets);
         }
@@ -73,6 +74,8 @@ export class KeyVaultHelper {
         return new Promise<void>((resolve, reject) => {
             var getSecretValuePromises: Promise<any>[] = [];
             secretsMap.forEach((secretName: string, secretEnv: string) => {
+                console.log(util.format("Downloading secret %s", secretName));
+
                 getSecretValuePromises.push(this.downloadSecretValue(secretName, secretEnv));
             });
 
@@ -85,14 +88,14 @@ export class KeyVaultHelper {
     }
 
     private downloadSecretValue(secretName: string, secretEnv: string): Promise<any> {
-        //secretName = secretName.trim();
-
         return new Promise<void>((resolve, reject) => {
             this.keyVaultClient.getSecretValue(secretName, (error, secretValue) => {
                 if (error) {
+                    console.log(util.format("Failed to download secret %s", secretName));
                     core.setFailed(util.format("Could not download the secret %s", secretName));
                 }
                 else {
+                    console.log(util.format("Downloaded secret %s", secretName));
                     this.setVaultVariable(secretEnv, secretValue);
                 }
                 
@@ -126,13 +129,22 @@ export class KeyVaultHelper {
 
     private readKeyValuesFromFile(filePattern: string): Map<string, string> {
       const keyValueMap: Map<string, string> = new Map();
+      console.log(`Reading key values from file pattern: ${filePattern}`);
       const filePaths = globSync(filePattern);
+      console.log(`Found ${filePaths.length} files matching the pattern: ${filePattern}`);
+
+      if (filePaths.length === 0){
+        core.setFailed("No files found matching the pattern: " + filePattern);
+      }
+
       for (const filePath of filePaths) {
+        console.log(`Reading key values from file: ${filePath}`);
         const fileContent = readFileSync(filePath, 'utf8');
-        const lines = fileContent.split('\n');
+        const lines = fileContent.split(',');
 
         for (const line of lines) {
           const trimmedLine = line.trim();
+          console.log(`Reading key values from line: ${trimmedLine}`);
           if (trimmedLine) {
             const [key, value] = trimmedLine.split('=');
             keyValueMap.set(key.trim(), value.trim());

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,16 +26,42 @@ async function run() {
         }
 
         if (handler != null) {
-            var actionParameters = new KeyVaultActionParameters().getKeyVaultActionParameters(handler);
-            var keyVaultHelper = new KeyVaultHelper(handler, 100, actionParameters);  
+          
             azPath = await io.which("az", true);
             var environment = await executeAzCliCommand("cloud show --query name");
             environment = environment.replace(/"|\s/g, '');
             console.log('Running keyvault action against ' + environment);
-            if (environment.toLowerCase() == "azurestack") {
-                await keyVaultHelper.initKeyVaultClient();
-            }    
-            keyVaultHelper.downloadSecrets();
+            var keyVaultName = core.getInput("keyvault");
+            var secrets = core.getInput("secrets");
+            if (keyVaultName && secrets)
+            {
+                // this code works only when keyvault and secrets are provided as input, for backward compatibility with the version 2
+                console.log('Running keyvault action against input param ' + keyVaultName);
+                console.log('Running keyvault action against with secrets ' + secrets);
+
+                var actionParameters = new KeyVaultActionParameters().getKeyVaultActionParameters(handler);
+                downloadSecrets(handler, environment, actionParameters);
+            }
+           
+            var keyVaultPairsInput = core.getInput("key_vault_with_secret_file_pairs")
+            if (keyVaultPairsInput){            
+                // param key_vault_with_secret_file_pairs in github action looks like this:
+                //      key_vault_with_secret_file_pairs: |
+                //          infra-eu-dev-kv=.github/env/eu/dev/key_vault1.env
+                //          business-eu-dev-kv=.github/env/eu/dev/key_vault2.env
+                var keyVaultPairs = keyVaultPairsInput.split('\n');
+
+                for (var i = 0; i < keyVaultPairs.length; i++) {
+                    var keyVaultPair = keyVaultPairs[i].split('=');
+                    var keyVault = keyVaultPair[0];
+                    var secretsFilePath = keyVaultPair[1];
+                    console.log('Running keyvault action against ' + keyVault);
+                    console.log('Running keyvault action against with secret file ' + secretsFilePath);
+
+                    var actionParameters = new KeyVaultActionParameters().getKeyVaultActionParametersForSpecificKeyVaultWithFile(handler, keyVault, secretsFilePath);
+                    downloadSecrets(handler, environment, actionParameters);
+                }
+            }
         }        
     } catch (error) {
         core.debug("Get secret failed with error: " + error);
@@ -44,6 +70,14 @@ async function run() {
     finally {
         core.exportVariable('AZURE_HTTP_USER_AGENT', prefix);
     }
+}
+
+async function downloadSecrets(handler: IAuthorizer, environment: string, actionParameters: KeyVaultActionParameters) {
+    var keyVaultHelper = new KeyVaultHelper(handler, 100, actionParameters);
+    if (environment.toLowerCase() == "azurestack") {
+        await keyVaultHelper.initKeyVaultClient();
+    }
+    keyVaultHelper.downloadSecrets();
 }
 
 async function executeAzCliCommand(command: string) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,8 +31,8 @@ async function run() {
             var environment = await executeAzCliCommand("cloud show --query name");
             environment = environment.replace(/"|\s/g, '');
             console.log('Running keyvault action against ' + environment);
-            var keyVaultName = core.getInput("keyvault");
-            var secrets = core.getInput("secrets");
+            var keyVaultName = core.getInput("keyvault").trim();
+            var secrets = core.getInput("secrets").trim();
             if (keyVaultName && secrets)
             {
                 // this code works only when keyvault and secrets are provided as input, for backward compatibility with the version 2
@@ -47,14 +47,14 @@ async function run() {
             if (keyVaultPairsInput){            
                 // param key_vault_with_secret_file_pairs in github action looks like this:
                 //      key_vault_with_secret_file_pairs: |
-                //          infra-eu-dev-kv=.github/env/eu/dev/key_vault1.env
+                //          infra-eu-dev-kv=.github/env/eu/dev/key_vault1.env,
                 //          business-eu-dev-kv=.github/env/eu/dev/key_vault2.env
-                var keyVaultPairs = keyVaultPairsInput.split('\n');
+                var keyVaultPairs = keyVaultPairsInput.split(',');
 
                 for (var i = 0; i < keyVaultPairs.length; i++) {
-                    var keyVaultPair = keyVaultPairs[i].split('=');
-                    var keyVault = keyVaultPair[0];
-                    var secretsFilePath = keyVaultPair[1];
+                    var keyVaultPair = keyVaultPairs[i].trim().split('=');
+                    var keyVault = keyVaultPair[0].trim();
+                    var secretsFilePath = keyVaultPair[1].trim();
                     console.log('Running keyvault action against ' + keyVault);
                     console.log('Running keyvault action against with secret file ' + secretsFilePath);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,7 @@ async function run() {
                 console.log('Running keyvault action against with secrets ' + secrets);
 
                 var actionParameters = new KeyVaultActionParameters().getKeyVaultActionParameters(handler);
-                downloadSecrets(handler, environment, actionParameters);
+                await downloadSecrets(handler, environment, actionParameters);
             }
            
             var keyVaultPairsInput = core.getInput("key_vault_with_secret_file_pairs")
@@ -59,7 +59,7 @@ async function run() {
                     console.log('Running keyvault action against with secret file ' + secretsFilePath);
 
                     var actionParameters = new KeyVaultActionParameters().getKeyVaultActionParametersForSpecificKeyVaultWithFile(handler, keyVault, secretsFilePath);
-                    downloadSecrets(handler, environment, actionParameters);
+                    await downloadSecrets(handler, environment, actionParameters);
                 }
             }
         }        


### PR DESCRIPTION
### Identify the issue

<!--

Optional field - JIRA text ID is enough.
Not every request should have a JIRA ticket.

-->

### Description of the Change

Added new optional param key_vault_with_secret_file_pairs

It represents pairs { **key_vault_name**: **file_path_with_secrets_mapping** }

Files with secrets contain { env_var: secret_name_from_key_vault } pairs.

Example of file content:
db_username=key-vault-db-username-secret,
db_password=key-vault-db-password-secret

Example of usage:
```
    key_vault_with_secret_file_pairs: |
          infra-eu-dev-kv=.github/env/eu/dev/key_vault1.env,
          business-eu-dev-kv=.github/env/eu/dev/key_vault2.env
```


For backward computability old params still workc, but they are optional so can be omitted

<!--

We must be able to understand the design of your change from this description. 
Keep in mind that the maintainer reviewing this PR may not be familiar with 
or have worked with the code here recently, so please walk us through the concepts.

-->

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? 
Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
Don't forget to add unit tests for your changes.

-->
